### PR TITLE
fix: adjustments to stack object

### DIFF
--- a/src/objects/object-stack.js
+++ b/src/objects/object-stack.js
@@ -2,5 +2,6 @@ export default class Stack {
     constructor(scene, x, y) {
         this.scene = scene;
         this.sprite = scene.physics.add.sprite(x, y, "sprite-stack", 0).setMaxVelocity(60, 60).setSize(32, 8);
+        this.spriteCollider = scene.physics.world.addCollider(this.sprite, scene.groundLayer);
     }
 }

--- a/src/objects/object-stack.js
+++ b/src/objects/object-stack.js
@@ -1,9 +1,6 @@
 export default class Stack {
     constructor(scene, x, y) {
         this.scene = scene;
-        this.sprite = scene.physics.add.sprite(x, y, "sprite-player", 0)
-            .setMaxVelocity(60, 60)
-            .setSize(32, 8)
-            .setOffset(2, 0);
+        this.sprite = scene.physics.add.sprite(x, y, "sprite-stack", 0).setMaxVelocity(60, 60).setSize(32, 8);
     }
 }

--- a/src/scenes/scene-action.js
+++ b/src/scenes/scene-action.js
@@ -48,7 +48,7 @@ export default class ActionScene extends Phaser.Scene {
             tileHeight: StackSettings.TileSize
         });
         this.groundLayer = map.createLayer(0, map.addTilesetImage("tileset-stacks", "tileset-stacks"), this.x, 0).setCollisionByExclusion([-1, 0]);
-        this.mainStack = new Stack(this, 16, 16);
+        this.mainStack = new Stack(this, 32, 32);
     }
     destroy() {
         if (this.groundLayer) {

--- a/src/utilities/utility-resources.js
+++ b/src/utilities/utility-resources.js
@@ -1,7 +1,7 @@
 export default class Resources {
     static BaseResources = new Map([
         ["image-background", { type: "images", name: "image-background", ext: "png" }],
-        ["sprite-stack", { type: "spritesheets", name: "sprite-player", ext: "png" }],
+        ["sprite-stack", { type: "spritesheets", name: "sprite-stack", ext: "png" }],
         ["tileset-stacks", { type: "tilesets", name: "tileset-stacks", ext: "png" }]
     ]);
     static createResources = (scene) => {


### PR DESCRIPTION
This change corrects the reference to the sprite assets and configures the basic collisions so that the stack does not fall off the screen. 