### PR TITLE
fix: adjust cut points on stacks

### DIFF
--- a/src/objects/object-stack.js
+++ b/src/objects/object-stack.js
@@ -1,11 +1,12 @@
 import { SpeedTypes } from "../utilities/utility-helpers.js";
 export default class Stack {
-    constructor(scene, x, y, currentFrame) {
+    constructor(scene, x, y, currentFrame, currentSize) {
         this.x = x;
         this.y = y;
         this.scene = scene;
         this.currentFrame = currentFrame;
-        this.sprite = scene.physics.add.sprite(x, y, "sprite-stack", currentFrame).setMaxVelocity(60, 60).setSize(32, 8);
+        this.currentSize = currentSize;
+        this.sprite = scene.physics.add.sprite(x, y, "sprite-stack", currentFrame).setMaxVelocity(60, 60).setSize(currentSize, 8).setOrigin(0.5, 0.5);
         this.spriteCollider = scene.physics.world.addCollider(this.sprite, scene.groundLayer);
         this.movementState = true;
         this.movementRight = true;

--- a/src/scenes/scene-action.js
+++ b/src/scenes/scene-action.js
@@ -19,19 +19,25 @@ export default class ActionScene extends Phaser.Scene {
         if (this.mainStacks.length > 0) {
             this.mainStacks[this.mainStacks.length - 1].update();
             if (this.mainStacks[this.mainStacks.length - 1].movementState === false) {
+                let currentSize = this.mainStacks[this.mainStacks.length - 1].currentSize;
                 let currentFrame = this.mainStacks[this.mainStacks.length - 1].currentFrame;
                 let currentX = this.mainStacks[this.mainStacks.length - 1].sprite.x;
                 let currentY = this.mainStacks[this.mainStacks.length - 1].sprite.y;
                 if (this.mainStacks.length > 1) {
                     let stackRecent = Math.round(this.mainStacks[this.mainStacks.length - 1].sprite.x);
                     let stackPrevious = Math.round(this.mainStacks[this.mainStacks.length - 2].sprite.x);
-                    let stackAbs = Math.abs(stackRecent - stackPrevious);
-                    currentFrame = currentFrame + stackAbs;
+                    let stackAbs = (stackRecent - stackPrevious);
+                    if (stackAbs <= 0) {
+                        currentSize = currentSize - Math.abs(stackAbs); 
+                    } else {
+                        currentSize = currentSize - stackAbs;
+                    }
+                    currentFrame = 32 - currentSize;
                 }
 	        if (currentFrame >= 32) {
 	            console.log("Game Over");
 	        } else {
-	            this.mainStacks.push(new Stack(this, currentX, currentY - 8, currentFrame));
+	            this.mainStacks.push(new Stack(this, currentX, currentY - 8, currentFrame, currentSize));
 	        }
             }
         }
@@ -68,7 +74,7 @@ export default class ActionScene extends Phaser.Scene {
         });
         this.groundLayer = map.createLayer(0, map.addTilesetImage("tileset-stacks", "tileset-stacks"), this.x, 0).setCollisionByExclusion([-1, 0]);
         if (this.mainStacks.length === 0) {
-            this.mainStacks.push(new Stack(this, 32, 60, 0));
+            this.mainStacks.push(new Stack(this, 32, 60, 0, 32));
         }
     }
     destroy() {


### PR DESCRIPTION
- Stacks were not cutting consistently, issue was due to incorrect origin points
- Stacks will now cut evenly on both sides
- TODO: make sure cuts are not factored when a small one is perfectly inside a large one; adjust offset collisions on sprite when there is a smaller one